### PR TITLE
Update await.md

### DIFF
--- a/docs/csharp/language-reference/keywords/await.md
+++ b/docs/csharp/language-reference/keywords/await.md
@@ -23,7 +23,7 @@ The `await` operator is applied to a task in an asynchronous method to insert a 
 > [!NOTE]
 >  The `async` and `await` keywords were introduced in C# 5. For an introduction to async programming, see [Asynchronous Programming with async and await](../../../csharp/programming-guide/concepts/async/index.md).  
   
-The task to which the `await` operator is applied typically is returned by a call to a method that implements the [Task-Based Asynchronous Pattern](../../../standard/asynchronous-programming-patterns/task-based-asynchronous-pattern-tap.md). They include methods that return <xref:System.Threading.Tasks.Task>, <xref:System.Threading.Tasks.Task%601>, and `System.Threading.Tasks.ValueType<TResult>` objects.  
+The task to which the `await` operator is applied typically is returned by a call to a method that implements the [Task-Based Asynchronous Pattern](../../../standard/asynchronous-programming-patterns/task-based-asynchronous-pattern-tap.md). They include methods that return <xref:System.Threading.Tasks.Task>, <xref:System.Threading.Tasks.Task%601>, and `System.Threading.Tasks.ValueTask<TResult>` objects.  
 
   
  In the following example, the <xref:System.Net.Http.HttpClient.GetByteArrayAsync%2A?displayProperty=nameWithType> method returns a `Task<byte[]>`. The task is a promise to produce the actual byte array when the task is complete. The `await` operator suspends execution until the work of the <xref:System.Net.Http.HttpClient.GetByteArrayAsync%2A> method is complete. In the meantime, control is returned to the caller of `GetPageSizeAsync`. When the task finishes execution, the `await` expression evaluates to a byte array.  


### PR DESCRIPTION
ValueTask (not ValueType) implements the task-based aynchronous pattern.

# Title
Fix ValueType/ValueTask typo

## Summary

ValueTask (not ValueType) implements the task-based aynchronous pattern.

## Details

## Suggested Reviewers
